### PR TITLE
Remove server-side user account validation

### DIFF
--- a/lib/scripts/adapters/identity.js
+++ b/lib/scripts/adapters/identity.js
@@ -1,4 +1,0 @@
-
-module.exports = function adaptIdentity(formData) {
-  return formData;
-}

--- a/lib/scripts/components/Identity.jsx
+++ b/lib/scripts/components/Identity.jsx
@@ -1,4 +1,3 @@
-
 var api = require('../services/api');
 var Grid = require('./Grid.jsx');
 var Form = require('./Form.jsx');
@@ -33,9 +32,9 @@ module.exports = React.createClass({
 
     var formErrors = getFormErrors(form);
 
-    if (formErrors.invalidFields.length > 0 || 
+    if (formErrors.invalidFields.length > 0 ||
       formErrors.invalidGamerProfiles.length === 4) {
-      
+
       this.setState({
         submitted: true,
         formErrors: formErrors
@@ -49,14 +48,13 @@ module.exports = React.createClass({
 
     this.setState({loading: true});
 
-    api.getUser(form, function (err, results) {    
-      if (err) return this.displayUserError(err);
-
+    function (results) {
       this.setState({
         profileResults: results,
         loading: false
       });
     }.bind(this));
+
   },
 
   handleChange: function (form) {
@@ -121,7 +119,7 @@ module.exports = React.createClass({
     var formBlocks = [];
 
     var range = BIO.fields.year.range,
-      years = [], 
+      years = [],
       y;
 
     for (y = range[0]; y >= range[1]; y -= 1) {
@@ -195,11 +193,11 @@ module.exports = React.createClass({
         </div>
       );
     }
-    
+
     var noteClass = classnames(
       'directions-note',
       {
-        invalid: this.state.submitted && 
+        invalid: this.state.submitted &&
           this.state.formErrors.invalidGamerProfiles.length === 4
       }
     );
@@ -216,7 +214,7 @@ module.exports = React.createClass({
         </div>
 
         <Form
-          id={FORM_ID} 
+          id={FORM_ID}
           className='inner'
           onChange={this.handleChange}
           onSubmit={this.submitProfiles}>
@@ -227,7 +225,7 @@ module.exports = React.createClass({
           <h6 className={noteClass}>
             You must fill out at least one game profile
           </h6>
-          
+
           <div>
             {formBlocks}
           </div>

--- a/lib/scripts/components/Identity.jsx
+++ b/lib/scripts/components/Identity.jsx
@@ -48,12 +48,21 @@ module.exports = React.createClass({
 
     this.setState({loading: true});
 
-    function (results) {
-      this.setState({
-        profileResults: results,
+    var profiles = ['BF4', 'BFHD', 'LOL', 'WOW']
+      .reduce(function(p, c) {
+          if (form[c + '_id']) {
+              p[c] = {
+                  "name": form[c + '_id'],
+                  "status": 'good'
+              }
+          }
+          return p;
+      }, {})
+
+    this.setState({
+        profileResults: profiles,
         loading: false
       });
-    }.bind(this));
 
   },
 

--- a/lib/scripts/services/api.js
+++ b/lib/scripts/services/api.js
@@ -1,4 +1,3 @@
-
 var request = require('superagent');
 var identityAdapter = require('../adapters/identity');
 var surveyAdapter = require('../adapters/survey');
@@ -23,26 +22,6 @@ api.submitQuestions = function (data, cb) {
       cb(err, JSON.parse(res.body));
     } catch (e) {
       cb(new Error('404'), {});
-    }
-  });
-};
-
-api.getUser = function (data, cb) {
-  if (!api.host) return cb(null, {});
-
-  request
-  .post(api.host + '/user')
-  .type('form')
-  .send(identityAdapter(data))
-  // .set('Accept', 'application/json')
-  .end(function (err, user) {
-    if (err) return cb(new Error('Something went wrong'), {});
-    try {
-      var data = JSON.parse(user.text);
-      cb(data.error, data);
-    } catch (e) {
-      // console.log(e);
-      cb(new Error('Something went wrong'), {});
     }
   });
 };

--- a/lib/scripts/services/api.js
+++ b/lib/scripts/services/api.js
@@ -1,5 +1,4 @@
 var request = require('superagent');
-var identityAdapter = require('../adapters/identity');
 var surveyAdapter = require('../adapters/survey');
 var api;
 


### PR DESCRIPTION
Outcome: "Adjusting the game account checks so participants without a valid game account can pass through to the tests and submit data." per @DarkSymmetry 

This removes the Identity checks that used to pass through API. Full validation of the profiles with multiple dimensions (e.g., regions) haven't been checked. 

When providing accounts that don't exist in the system you should see something like 

  https://www.dropbox.com/s/l5sdi7rkgv9nqtv/Screenshot%202016-01-27%2011.26.15.png?dl=0

Validation: http://projectgamr-dev.media.mit.edu/identity

CR: @skiano 
